### PR TITLE
Fix missing imports for network scan utilities

### DIFF
--- a/server/routes.ts
+++ b/server/routes.ts
@@ -3,6 +3,9 @@ import { createServer, type Server } from "http";
 import axios from "axios";
 import esphomeApi from "esphome-native-api";
 import { lookup } from "node:dns/promises";
+import mdns from "multicast-dns";
+import { networkInterfaces } from "node:os";
+import net, { Socket } from "node:net";
 
 const { Client: ESPHomeClient, Connection: ESPHomeConnection } = esphomeApi as any;
 import { storage } from "./storage";


### PR DESCRIPTION
## Summary
- add missing imports to `server/routes.ts`

## Testing
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_687d5ca2cf9c833097c44fc0242b2cab